### PR TITLE
html title

### DIFF
--- a/leda/gen/base.py
+++ b/leda/gen/base.py
@@ -20,6 +20,7 @@ logger.addHandler(logging.NullHandler())
 class Report:
     name: str
 
+    html_title: str | None = None
     tag: str | None = None
 
     params: Mapping[str, Any] | None = None
@@ -101,7 +102,7 @@ class ReportArtifact:
 @dataclasses.dataclass()
 class ReportGenerator:
     def generate(
-        self, nb_contents: nbformat.NotebookNode, nb_name: str | None = None
+        self, nb_contents: nbformat.NotebookNode, html_title: str | None = None
     ) -> bytes:
         raise NotImplementedError
 

--- a/leda/gen/generators.py
+++ b/leda/gen/generators.py
@@ -140,7 +140,7 @@ class MainStaticReportGenerator(leda.gen.base.ReportGenerator):
     def generate(
         self,
         nb_contents: nbformat.NotebookNode,
-        nb_name: str | None = None,
+        html_title: str | None = None,
     ) -> bytes:
         logger.info("Generating notebook")
         preprocessor = self._get_preprocessor()
@@ -154,9 +154,9 @@ class MainStaticReportGenerator(leda.gen.base.ReportGenerator):
         body, _ = exporter.from_notebook_node(nb_contents)
 
         logger.info("Modifying HTML")
-        if nb_name:
+        if html_title:
             body = body.replace(
-                "<title>Notebook</title>", f"<title>{nb_name}</title>"
+                "<title>Notebook</title>", f"<title>{html_title}</title>"
             )
 
         return body.encode(errors="ignore")

--- a/leda/gen/runners.py
+++ b/leda/gen/runners.py
@@ -27,7 +27,9 @@ class MainReportRunner(leda.gen.base.ReportRunner):
 
         self.modifier.modify(nb_contents)
 
-        body = self.generator.generate(nb_contents, nb_name=report.name)
+        html_title = report.html_title if report.html_title else report.name
+
+        body = self.generator.generate(nb_contents, html_title=html_title)
         artifact = leda.gen.base.ReportArtifact(body)
 
         return self.publisher.publish(report, artifact)


### PR DESCRIPTION
* adds `html_title` to `Report` class so that we can customize the html title of a report
* renames `nb_name` to `html_title` in the `ReportGenerator`, as it was only being used for setting the html title anyway