### PR TITLE
Include python3.13 and fix pyright Windows issue in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,11 +71,12 @@ jobs:
 
       - name: Integration test with nox
         run: nox -t integration_test --python ${{ matrix.python-version }}
-        # Skip integration tests on Windows/py3.8 because
-        # there are no pre-built Windows/py3.8/numpy1.6.6 wheels.
-        # Skip py3.9 because none of the bundles are for it.
-        # TODO: Investigate issues on Windows and pypy.
-        if: ${{ (matrix.python-version != '3.9') && ! (matrix.os == 'windows-latest' && matrix.python-version == '3.8') && ! startsWith(matrix.python-version, 'pypy-') }}
+        # Notes:
+        #   - Skip py3.9 and py3.13 because none of the bundles are for it.
+        #   - Skip integration tests on Windows/py3.8 because
+        #   there are no pre-built Windows/py3.8/numpy1.6.6 wheels.
+        #   - TODO: Investigate issues on Windows and pypy.
+        if: ${{ (matrix.python-version != '3.9') && (matrix.python-version != '3.13') && ! (matrix.os == 'windows-latest' && matrix.python-version == '3.8') && ! startsWith(matrix.python-version, 'pypy-') }}
 
       - name: Upload failed outputs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           # TODO: Switch back to `macos-latest` when we fix small issues with macOS 14 ARM
           - macos-13
           - windows-latest
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8']
         exclude:
           # It looks like the issue with with macos-13/python3.8 is that the
           # GitHub image for macos-13 switched from gcc 11 to 12, and this makes

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,6 +76,12 @@ def mypy(session: nox.Session) -> None:
 
 @nox.session(tags=["static", "typecheck"])
 def pyright(session: nox.Session) -> None:
+    # TODO: Remove once pyright >= 1.1.387 is available. See:
+    #   - https://github.com/microsoft/pyright/issues/9296
+    #   - https://docs.python.org/3/library/sys.html#sys.platform
+    if sys.platform == "win32":
+        session.install("pyright <= 1.1.385")
+
     if is_isolated_venv(session):
         session.install("-e", ".[test]")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Libraries


### PR DESCRIPTION
* Include python3.13 in CI testing
* Fix pyright Windows issue by constraining version temporarily
  * See https://github.com/microsoft/pyright/issues/9296