### PR TITLE
Fix CI by pinning version of mistune

### DIFF
--- a/requirements-bundle4.txt
+++ b/requirements-bundle4.txt
@@ -6,6 +6,7 @@ jupyter-client == 8.6.0  # For dynamic mode
 jupyter-core == 5.7.1  # For dynamic mode
 markdown2 == 2.4.12
 matplotlib == 3.8.3
+mistune == 3.0.2  # Not directly used
 nbclient == 0.9.0  # Not directly used
 nbconvert == 7.16.1
 nbformat == 5.9.2


### PR DESCRIPTION
Pin `mistune` to before v3.1.0 in bundle 4 to avoid incompatibility with `nbconvert`:

```
  File "/home/runner/work/leda/leda/.nox/integration_test_bundle4/lib/python3.12/site-packages/nbconvert/filters/markdown_mistune.py", line 472, in __init__
    block = MathBlockParser()
            ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/leda/leda/.nox/integration_test_bundle4/lib/python3.12/site-packages/mistune/block_parser.py", line 111, in __init__
    name: getattr(self, 'parse_' + name) for name in self.SPECIFICATION
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MathBlockParser' object has no attribute 'parse_axt_heading'. Did you mean: 'parse_atx_heading'?
```

See https://github.com/lepture/mistune/releases/tag/v3.1.0 (specifically: https://github.com/lepture/mistune/commit/6e17864cf53bbb0a99643b29865e5dfd47b7e8f4).