### PR TITLE
Fix CI by pinning pillow and add debugging tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade setuptools "virtualenv<=20.28.0" pip wheel
+          python -m pip install --upgrade setuptools pip wheel
           python -m pip install nox
         if: ${{ ! (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       # TODO: Run tests on windows/pypy-3.8
 
       - name: Integration test with nox
-        run: nox -t integration_test --python ${{ matrix.python-version }} --gen-html-diffs
+        run: nox -t integration_test --python ${{ matrix.python-version }} -- --gen-html-diffs
         # Notes:
         #   - Skip py3.9 and py3.13 because none of the bundles are for it.
         #   - Skip integration tests on Windows/py3.8 because

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       # TODO: Run tests on windows/pypy-3.8
 
       - name: Integration test with nox
-        run: nox -t integration_test --python ${{ matrix.python-version }}
+        run: nox -t integration_test --python ${{ matrix.python-version }} --gen-html-diffs
         # Notes:
         #   - Skip py3.9 and py3.13 because none of the bundles are for it.
         #   - Skip integration tests on Windows/py3.8 because

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade setuptools pip wheel
+          python -m pip install --upgrade setuptools "virtualenv<=20.28.0" pip wheel
           python -m pip install nox
         if: ${{ ! (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
 

--- a/check_pkgs.py
+++ b/check_pkgs.py
@@ -1,0 +1,105 @@
+"""Check PyPI package published on or after given asof datetime.
+
+E.g.:
+
+```bash
+python ./check_pkgs.py ./packages.txt "2025-01-01"
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import functools
+import logging
+import pathlib
+from typing import TypeVar, cast
+import xml.etree.ElementTree as xml_etree
+
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def unwrap(value: T | None) -> T:
+    assert value is not None
+    return value
+
+
+def fetch_package_rss(package_name: str) -> bytes:
+    """Fetch the RSS feed for a given PyPI package."""
+    url = f"https://pypi.org/rss/project/{package_name}/releases.xml"
+
+    response = requests.get(url)
+    response.raise_for_status()
+    assert response.content is not None  # For typing
+    return cast(bytes, response.content)
+
+
+def parse_package_rss(
+    rss_content: bytes, package_name: str, asof: datetime.datetime
+) -> None:
+    """Parse the RSS feed and extract releases asof given dt."""
+    logger.debug("Checking %r", package_name)
+    root = xml_etree.fromstring(rss_content)
+    items = root.findall(".//item")
+    for item in items:
+        title = unwrap(item.find("title")).text
+        pub_date = unwrap(item.find("pubDate")).text
+        pub_ts = pd.to_datetime(pub_date, utc=True)  # pyright: ignore
+
+        logger.debug("Published %s %s on %s", package_name, title, pub_ts)
+
+        if pub_ts > asof:
+            logger.info("Published %s %s on %s!", package_name, title, pub_ts)
+
+
+def check_packages(
+    package_constraints: list[str], asof: datetime.datetime
+) -> None:
+    for package_constraint in package_constraints:
+        if (
+            not package_constraint
+            or "-e" in package_constraint
+            or package_constraint.startswith("#")
+        ):
+            continue
+
+        if "==" in package_constraint:
+            package_name, _ = package_constraint.split("==")
+        else:
+            package_name = package_constraint
+
+        package_rss_content = fetch_package_rss(package_name)
+        parse_package_rss(package_rss_content, package_name, asof)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=pathlib.Path)
+    parser.add_argument(
+        "asof", type=functools.partial(pd.to_datetime, utc=True)
+    )
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=args.log_level)
+
+    logger.info("Reading package file")
+    package_constraints = (
+        cast(pathlib.Path, args.path).read_text().splitlines()
+    )
+    asof = cast(pd.Timestamp, args.asof).to_pydatetime()
+
+    logger.info("Checking packages")
+    check_packages(package_constraints, asof)
+
+    logger.info("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/leda/tests/integration/run_test.py
+++ b/leda/tests/integration/run_test.py
@@ -253,6 +253,7 @@ def clean_report(text: str) -> str:
 
 
 def _handle_diffs(
+    path: pathlib.Path,
     tag: str,
     ref_result_lines: Sequence[str],
     test_result_lines: Sequence[str],
@@ -275,7 +276,7 @@ def _handle_diffs(
 
     if generate_html_diffs:
         logger.info("Generating HTML diff")
-        diff_html_path = pathlib.Path.cwd() / f"{tag}-diff.html"
+        diff_html_path = path / f"{tag}-diff.html"
         html = difflib.HtmlDiff(wrapcolumn=79).make_file(
             ref_result_lines,
             test_result_lines,
@@ -365,6 +366,7 @@ def _run_test(
         )
     )
     _handle_diffs(
+        path=test_result_path,
         tag=tag,
         ref_result_lines=ref_result_lines,
         test_result_lines=test_result_lines,

--- a/leda/tests/integration/run_test.py
+++ b/leda/tests/integration/run_test.py
@@ -253,7 +253,7 @@ def clean_report(text: str) -> str:
 
 
 def _handle_diffs(
-    path: pathlib.Path,
+    output_dir: pathlib.Path,
     tag: str,
     ref_result_lines: Sequence[str],
     test_result_lines: Sequence[str],
@@ -276,14 +276,17 @@ def _handle_diffs(
 
     if generate_html_diffs:
         logger.info("Generating HTML diff")
-        diff_html_path = path / f"{tag}-diff.html"
         html = difflib.HtmlDiff(wrapcolumn=79).make_file(
             ref_result_lines,
             test_result_lines,
             context=True,
             numlines=10,
         )
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        diff_html_path = output_dir / f"{tag}-diff.html"
         diff_html_path.write_text(html, encoding="utf-8")
+
         logger.info(
             "Generated HTML diff: file://%s",
             diff_html_path,
@@ -366,7 +369,7 @@ def _run_test(
         )
     )
     _handle_diffs(
-        path=test_result_path,
+        output_dir=test_result_path.parent,
         tag=tag,
         ref_result_lines=ref_result_lines,
         test_result_lines=test_result_lines,

--- a/noxfile.py
+++ b/noxfile.py
@@ -180,7 +180,9 @@ def _run_integration_test(session: nox.Session, bundle_name: str) -> None:
     session.install("-r", requirements_filename, "-c", requirements_filename)
     session.install("-e", ".[demos,test]")
 
-    # To ease debugging
+    # To help debugging
+    session.run("jupyter", "labextension", "list")
+    session.run("jupyter", "nbextension", "list")
     session.run("pip", "freeze")
 
     # Run test

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,7 +181,6 @@ def _run_integration_test(session: nox.Session, bundle_name: str) -> None:
     session.install("-e", ".[demos,test]")
 
     # To help debugging
-    session.run("jupyter", "nbextension", "list")
     session.run("pip", "freeze")
 
     # Run test

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,7 +181,6 @@ def _run_integration_test(session: nox.Session, bundle_name: str) -> None:
     session.install("-e", ".[demos,test]")
 
     # To help debugging
-    session.run("jupyter", "labextension", "list")
     session.run("jupyter", "nbextension", "list")
     session.run("pip", "freeze")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -180,6 +180,10 @@ def _run_integration_test(session: nox.Session, bundle_name: str) -> None:
     session.install("-r", requirements_filename, "-c", requirements_filename)
     session.install("-e", ".[demos,test]")
 
+    # To ease debugging
+    session.run("pip", "freeze")
+
+    # Run test
     args = []
     if "--gen-html-diffs" in session.posargs:
         args.append("--gen-html-diffs")

--- a/requirements-bundle2.txt
+++ b/requirements-bundle2.txt
@@ -19,3 +19,4 @@ plotly == 5.5.0
 Pygments == 2.15.1
 termcolor == 2.1.1
 tqdm == 4.62.3
+virtualenv == 20.28.0

--- a/requirements-bundle2.txt
+++ b/requirements-bundle2.txt
@@ -19,4 +19,3 @@ plotly == 5.5.0
 Pygments == 2.15.1
 termcolor == 2.1.1
 tqdm == 4.62.3
-virtualenv == 20.28.0

--- a/requirements-bundle2.txt
+++ b/requirements-bundle2.txt
@@ -15,6 +15,7 @@ notebook == 6.5.2  # For dynamic mode
 pandas == 1.3.5  # For demos
 numpy == 1.22.4  # For demos
 panel == 0.14.1  # For panel static interact mode
+pillow == 11.0.0
 plotly == 5.5.0
 Pygments == 2.15.1
 termcolor == 2.1.1

--- a/requirements-bundle3.txt
+++ b/requirements-bundle3.txt
@@ -17,3 +17,4 @@ plotly == 5.11.0
 Pygments == 2.15.1
 termcolor == 2.1.1
 tqdm == 4.64.1
+virtualenv == 20.28.0

--- a/requirements-bundle3.txt
+++ b/requirements-bundle3.txt
@@ -13,6 +13,7 @@ notebook == 6.5.2  # For dynamic mode
 numpy == 1.24.0  # For demos
 pandas == 1.5.2  # For demos
 panel == 0.14.2  # For panel static interact mode
+pillow == 11.0.0
 plotly == 5.11.0
 Pygments == 2.15.1
 termcolor == 2.1.1

--- a/requirements-bundle3.txt
+++ b/requirements-bundle3.txt
@@ -17,4 +17,3 @@ plotly == 5.11.0
 Pygments == 2.15.1
 termcolor == 2.1.1
 tqdm == 4.64.1
-virtualenv == 20.28.0

--- a/requirements-bundle4.txt
+++ b/requirements-bundle4.txt
@@ -18,3 +18,4 @@ plotly == 5.19.0
 Pygments == 2.17.2
 termcolor == 2.4.0
 tqdm == 4.66.2
+virtualenv == 20.28.0

--- a/requirements-bundle4.txt
+++ b/requirements-bundle4.txt
@@ -14,6 +14,7 @@ notebook == 7.1.0  # For dynamic mode
 numpy == 1.26.4  # For demos
 pandas == 2.2.1  # For demos
 panel == 1.3.8  # For panel static interact mode
+pillow == 11.0.0
 plotly == 5.19.0
 Pygments == 2.17.2
 termcolor == 2.4.0

--- a/requirements-bundle4.txt
+++ b/requirements-bundle4.txt
@@ -18,4 +18,3 @@ plotly == 5.19.0
 Pygments == 2.17.2
 termcolor == 2.4.0
 tqdm == 4.66.2
-virtualenv == 20.28.0


### PR DESCRIPTION
* Pin packages to fix CI
  * FYI: bundles are deliberately kept loose/unpinned (i.e., not full lock file) to react to newer libraries, but maybe we could reconsider this idea
* Add `pip freeze` to help debug
* Add check packages script to see PyPI package publish dates to help debug
* Enable HTML diffs in integration tests to help debug