### PR TITLE
Fix Ubuntu 24.04 python3.8 CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           # TODO: Switch back to `macos-latest` when we fix small issues with macOS 14 ARM
           - macos-13
           - windows-latest
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
         exclude:
           # It looks like the issue with with macos-13/python3.8 is that the
           # GitHub image for macos-13 switched from gcc 11 to 12, and this makes
@@ -51,32 +51,35 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies (ubuntu-latest, py3.8)
+      - name: Install apt dependencies (ubuntu-latest)
         run: |
           # See https://github.com/matplotlib/matplotlib/issues/22113
           sudo apt install libfreetype-dev
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
+
+      - name: Install pip dependencies (ubuntu-latest, py3.8)
+        run: |
           python -m pip install --upgrade "setuptools<74" "virtualenv<=20.26.3" pip wheel
           python -m pip install nox
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
 
-      - name: Install dependencies
+      - name: Install pip dependencies
         run: |
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install nox
         if: ${{ ! (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
 
+      # TODO: Run tests on windows/pypy-3.10
       - name: Test with nox
         run: nox
-        if: ${{ ! (matrix.os == 'windows-latest' && matrix.python-version == 'pypy-3.9') }}
-
-      # TODO: Run tests on windows/pypy-3.9
+        if: ${{ ! (matrix.os == 'windows-latest' && matrix.python-version == 'pypy-3.10') }}
 
       - name: Integration test with nox
         run: nox -t integration_test --python ${{ matrix.python-version }} -- --gen-html-diffs
         # Notes:
         #   - Skip py3.9 and py3.13 because none of the bundles are for it.
         #   - Skip integration tests on Windows/py3.8 because
-        #   there are no pre-built Windows/py3.8/numpy1.6.6 wheels.
+        #     there are no pre-built Windows/py3.8/numpy1.6.6 wheels.
         #   - TODO: Investigate issues on Windows and pypy.
         if: ${{ (matrix.python-version != '3.9') && (matrix.python-version != '3.13') && ! (matrix.os == 'windows-latest' && matrix.python-version == '3.8') && ! startsWith(matrix.python-version, 'pypy-') }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           # TODO: Switch back to `macos-latest` when we fix small issues with macOS 14 ARM
           - macos-13
           - windows-latest
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.9']
         exclude:
           # It looks like the issue with with macos-13/python3.8 is that the
           # GitHub image for macos-13 switched from gcc 11 to 12, and this makes
@@ -67,9 +67,9 @@ jobs:
 
       - name: Test with nox
         run: nox
-        if: ${{ ! (matrix.os == 'windows-latest' && matrix.python-version == 'pypy-3.8') }}
+        if: ${{ ! (matrix.os == 'windows-latest' && matrix.python-version == 'pypy-3.9') }}
 
-      # TODO: Run tests on windows/pypy-3.8
+      # TODO: Run tests on windows/pypy-3.9
 
       - name: Integration test with nox
         run: nox -t integration_test --python ${{ matrix.python-version }} -- --gen-html-diffs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Install dependencies (ubuntu-latest, py3.8)
         run: |
+          # See https://github.com/matplotlib/matplotlib/issues/22113
+          sudo apt install libfreetype-dev
           python -m pip install --upgrade "setuptools<74" "virtualenv<=20.26.3" pip wheel
           python -m pip install nox
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}


### PR DESCRIPTION
* Latest Ubuntu runner was upgraded from 22.04.5 -> 24.04.1, breaking the installation of matplotlib
  * We're still supporting py3.8, so we fix this by installing `libfreetype-dev` (see https://github.com/matplotlib/matplotlib/issues/22113#issuecomment-1005742251)
* Bump pypy 3.8 -> 3.10