### PR TITLE
include microseconds in report name to prevent collisions

### DIFF
--- a/leda/gen/base.py
+++ b/leda/gen/base.py
@@ -37,7 +37,7 @@ class Report:
         else:
             parts = [self.name]
 
-        parts.append(datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S"))
+        parts.append(datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S.%f"))
 
         return "-".join(parts)
 


### PR DESCRIPTION
- when multiple reports finish at the same time, they may collide in report name and lead to clobbering each other
- `Report`'s `tag` field can be used to make unique report names, but it'd be nice to be able to sort report results by timestamp