### PR TITLE
Pin matplotlilb_inline version in integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,19 +168,20 @@ gen-integration-test0 = "python ./leda/tests/integration/run_test.py test0 --gen
 python = "~=3.10.0"
 ipython = "==8.0.1"
 ipywidgets = "==7.6.6"
-jedi = "==0.18.2"          # Fix compatibility issue.
-Jinja2 = "==3.0.3"         # Fix compatibility issue.
-jupyter_client = "==7.4.8" # For dynamic mode.
-jupyter_core = "==5.1.0"   # For dynamic mode.
+jedi = "==0.18.2"             # Fix compatibility issue.
+Jinja2 = "==3.0.3"            # Fix compatibility issue.
+jupyter_client = "==7.4.8"    # For dynamic mode.
+jupyter_core = "==5.1.0"      # For dynamic mode.
 markdown2 = "==2.4.6"
 matplotlib = "==3.5.3"
-nbclient = "==0.5.13"      # Not directly used.
+matplotlib_inline = "==0.1.7"
+nbclient = "==0.5.13"         # Not directly used.
 nbconvert = "==6.4.5"
 nbformat = "==5.3.0"
-notebook = "==6.5.2"       # For dynamic mode.
-pandas = "==1.3.5"         # For examples.
-numpy = "==1.22.4"         # For examples.
-panel = "==0.14.1"         # For panel static interact mode.
+notebook = "==6.5.2"          # For dynamic mode.
+pandas = "==1.3.5"            # For examples.
+numpy = "==1.22.4"            # For examples.
+panel = "==0.14.1"            # For panel static interact mode.
 pillow = "==11.0.0"
 plotly = "==5.5.0"
 Pygments = "==2.15.1"
@@ -194,18 +195,19 @@ gen-integration-test2 = "python ./leda/tests/integration/run_test.py test2 --gen
 [tool.pixi.feature.integration-test3.dependencies]
 python = "~=3.11.0"
 ipython = "==8.7.0"
-ipywidgets = "==7.8.5"     # Originally 8.0.3, but that's not compatible.
-jupyter_client = "==7.4.8" # For dynamic mode.
-jupyter_core = "==5.1.0"   # For dynamic mode.
+ipywidgets = "==7.8.5"        # Originally 8.0.3, but that's not compatible.
+jupyter_client = "==7.4.8"    # For dynamic mode.
+jupyter_core = "==5.1.0"      # For dynamic mode.
 markdown2 = "==2.4.6"
 matplotlib = "==3.6.2"
-nbclient = "==0.7.2"       # Not directly used.
+matplotlib_inline = "==0.1.7"
+nbclient = "==0.7.2"          # Not directly used.
 nbconvert = "==7.2.7"
 nbformat = "==5.7.1"
-notebook = "==6.5.2"       # For dynamic mode.
-numpy = "==1.24.0"         # For examples.
-pandas = "==1.5.2"         # For examples.
-panel = "==0.14.2"         # For panel static interact mode.
+notebook = "==6.5.2"          # For dynamic mode.
+numpy = "==1.24.0"            # For examples.
+pandas = "==1.5.2"            # For examples.
+panel = "==0.14.2"            # For panel static interact mode.
 pillow = "==11.0.0"
 plotly = "==5.11.0"
 Pygments = "==2.15.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,7 @@ jupyter_client = "==7.4.8"    # For dynamic mode.
 jupyter_core = "==5.1.0"      # For dynamic mode.
 markdown2 = "==2.4.6"
 matplotlib = "==3.5.3"
-matplotlib_inline = "==0.1.7"
+matplotlib-inline = "==0.1.7"
 nbclient = "==0.5.13"         # Not directly used.
 nbconvert = "==6.4.5"
 nbformat = "==5.3.0"
@@ -200,7 +200,7 @@ jupyter_client = "==7.4.8"    # For dynamic mode.
 jupyter_core = "==5.1.0"      # For dynamic mode.
 markdown2 = "==2.4.6"
 matplotlib = "==3.6.2"
-matplotlib_inline = "==0.1.7"
+matplotlib-inline = "==0.1.7"
 nbclient = "==0.7.2"          # Not directly used.
 nbconvert = "==7.2.7"
 nbformat = "==5.7.1"


### PR DESCRIPTION
Before, we weren't pinning `matplotlib-inline`, but then v0.2.1 was released, and this version is not compatible with the (already) pinned versions of `matplotlib` in the integration tests. See https://prefix.dev/channels/conda-forge/packages/matplotlib-inline.